### PR TITLE
Fixed two minor issues in evaluation pipeline

### DIFF
--- a/rl_train/analyzer/train_log_analyzer.py
+++ b/rl_train/analyzer/train_log_analyzer.py
@@ -76,7 +76,7 @@ class TrainLogAnalyzer:
                         weight_value = modified_log_datas[0].reward_weights.get(key, 1.0)
                         if isinstance(weight_value, dict):
                             # Sum all values in the dictionary for each timestep
-                            reward_weights[key] = [sum(weight_dict.values()) for weight_dict in 
+                            reward_weights[key] = [sum(weight_dict) for weight_dict in 
                                                    (log_data.reward_weights.get(key, {}).values() for log_data in modified_log_datas)]
                         else:
                             # Directly use the weight if it's not a dictionary

--- a/rl_train/run_policy_eval.py
+++ b/rl_train/run_policy_eval.py
@@ -109,7 +109,7 @@ for (idx, evaluate_param) in enumerate(config.evaluate_param_list):
 
     gait_analyzer.plot_entire_result(result_dir=analyze_result_dir,is_right_foot_based=True)
 
-    gait_analyzer.plot_exo_segmented_data(result_dir=analyze_result_dir)
+    gait_analyzer.plot_exo_segmented_data(result_dir=analyze_result_dir) if config.env_params.env_id in ["myoAssistLegImitationExo-v0"] else None
 
     gait_analyzer.plot_segmented_kinematics_result(result_dir=analyze_result_dir)
 


### PR DESCRIPTION
- Removed .values() call in train_log_analyzer.py (Line 79) which errors out when trying to sum weight values for qpos and qvel dictionaries.
- Added conditional if to run_policy_eval.py when using "myoAssistLegImitation-v0". Errors out and doesn't produce downstream graphs.