### PR TITLE
Rework installation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,10 +24,13 @@ jobs:
       - name: Lint and format check (ruff)
         run: ruff check . && ruff format --check .
 
-  # The suite needs the composed pipeline (myosuite + SB3 + the git-URL sibling repos), so
-  # it installs the full deps and runs test_setup.py. All three sibling repos
-  # (myo_sim / assist_sim / myoassist.terrains) are public, so the git-URL installs in
-  # requirements.txt resolve on a runner and this runs on both branches.
+  # The suite needs the composed pipeline (myosuite + SB3 + the PyPI sibling packages), so
+  # it installs the full deps and runs test_setup.py. The siblings (myo-sim / assist-sim /
+  # myoassist-terrains) are on PyPI, so the install resolves without any git clone.
+  #
+  # Install uses uv, not pip: MyoSuite 2.8.4's metadata pins an older mujoco, and the
+  # `[tool.uv] override-dependencies` in pyproject.toml relaxes it so the stack resolves in
+  # one command. Plain pip cannot do this and fails with a resolution error.
   #
   # Matrix mirrors setup.py's python_requires (>=3.11); do not add 3.10 back without
   # relaxing that floor.
@@ -43,10 +46,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: pip
+      - uses: astral-sh/setup-uv@v10.0.0
+        with:
+          enable-cache: true
       - name: Install myoassist + dev deps
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e . -r requirements-dev.txt
+        run: uv pip install --system -e . -r requirements-dev.txt
       - name: Run setup checks
         run: python test_setup.py

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ and the ready-to-run specs in [`docs/examples/`](docs/examples/).
 ### Prerequisites
 - Python 3.11+
 - Git
-- MuJoCo ≥ 3.3.4 (installed automatically as a dependency)
+- [uv](https://docs.astral.sh/uv/) (the installer; Step 3 explains why)
+- MuJoCo ≥ 3.4 (installed automatically as a dependency)
 
 ### Setup
 
@@ -75,14 +76,17 @@ and the ready-to-run specs in [`docs/examples/`](docs/examples/).
    .my_venv\Scripts\activate
    ```
 
-3. **Install the package and dependencies:**
+3. **Install uv, then the package:**
    ```bash
-   pip install -e . -r requirements.txt
+   pip install uv
+   uv pip install -e .
    ```
-   `requirements.txt` installs the three sibling packages (`myo_sim`, `assist_sim`,
-   `myoassist.terrains`) directly from git, since they are not yet on PyPI. Contributors doing
-   multi-repo development should instead clone those three locally and `pip install -e` each so
-   local edits are picked up (see the comments in `requirements.txt`).
+   MyoAssist installs with `uv`, not plain `pip`. MyoSuite 2.8.4 pins an older MuJoCo in its
+   metadata, but the framework needs MuJoCo 3.4 for the sibling packages (`myo-sim`,
+   `assist-sim`, `myoassist-terrains`). The `[tool.uv]` override in `pyproject.toml` relaxes
+   that pin, so `uv` resolves the whole stack in one command. Plain `pip` cannot do this and
+   stops with a resolution error. Contributors doing multi-repo development can clone the
+   three siblings and run `uv pip install -e` on each, so local edits are picked up.
 
 4. **Verify the installation:**
    ```bash
@@ -131,7 +135,8 @@ myoassist/
 │   └── env_spec.py      #   EnvSpec: validated {msk, device, terrain}
 ├── docs/                # Lightweight in-repo documentation + examples
 ├── setup.py             # Package configuration
-├── requirements.txt     # Dependencies (incl. git-hosted siblings)
+├── pyproject.toml       # Build backend + uv dependency override
+├── requirements.txt     # Dependencies (PyPI siblings)
 └── test_setup.py        # Installation verification
 ```
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -6,9 +6,11 @@ Welcome to MyoAssist! This section will help you get up and running with the fra
 
 Before you begin, make sure you have:
 - [Python 3.11](https://www.python.org/downloads/release/python-3119/) (Make sure to add Python to PATH during installation)
+- [uv](https://docs.astral.sh/uv/) (the installer; Step 3 explains why)
 - [Visual Studio Code](https://code.visualstudio.com/download) (Or other IDE)
-- [MuJoCo 3.3.3](https://github.com/google-deepmind/mujoco/releases/tag/3.3.3)
 - [Git](https://git-scm.com/downloads)
+
+MuJoCo 3.4 or newer installs automatically with the package.
 
 ## Installation
 
@@ -69,10 +71,19 @@ Virtual environments (venv) are essential because they allow you to create isola
 
 After creating and activating the virtual environment, you can install the required packages. This ensures that your dependencies are managed per project and do not affect your global Python installation.
 
-### Step 3: Install the Package
+### Step 3: Install uv and the Package
+
+Install uv once, then install MyoAssist with it:
+
 ```bash
-pip install -e .
+pip install uv
+uv pip install -e .
 ```
+
+MyoAssist installs with `uv`, not plain `pip`. MyoSuite 2.8.4 pins an older MuJoCo in its
+metadata, but the framework needs MuJoCo 3.4 for the sibling packages. The `[tool.uv]`
+override in `pyproject.toml` relaxes that pin, so `uv` resolves everything in one command.
+Plain `pip` cannot do this and stops with a resolution error.
 
 ### Step 4: Verify Installation
 
@@ -85,8 +96,8 @@ You should see output similar to this:
 ```bash
 Test Summary
 ----------------------------------------
-Total tests: 13
-Passed: 13
+Total tests: 15
+Passed: 15
 Failed: 0
 Total time: 13.60s
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+# Package metadata (name, version, packages, dependencies) lives in setup.py and
+# requirements.txt. This file only adds the build backend and the uv override below.
+
+[tool.uv]
+# MyoAssist installs MyoSuite 2.8.4, whose packaging metadata pins mujoco==3.1.2 and
+# dm-control==1.0.16. The sibling packages (myo-sim, assist-sim, myoassist-terrains)
+# require mujoco>=3.4, and MyoSuite 2.8.4 runs correctly on mujoco 3.4. This override
+# relaxes those two transitive pins so `uv pip install -e .` resolves the whole stack
+# in one command. Plain pip has no per-dependency override and cannot do this.
+#
+# dm-control is pinned to 1.0.36 (not MyoSuite's 1.0.16): 1.0.36 is the first dm-control
+# release that targets mujoco 3.4.0. Older dm-control (<=1.0.34) indexes the MjData field
+# `B_colind`, which mujoco 3.4 moved to MjModel, so MyoSuite's dm-control physics backend
+# crashes on env creation with 1.0.31. 1.0.37+ requires mujoco>=3.5, above our ceiling.
+override-dependencies = ["mujoco>=3.4,<3.5", "dm-control==1.0.36"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 # Development dependencies. Install with:
-#   pip install -r requirements.txt -r requirements-dev.txt
+#   uv pip install -e . -r requirements-dev.txt
 
 -r requirements.txt
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,23 +6,29 @@ termcolor
 flatten_dict
 h5py
 numpy==2.2.6
-mujoco>=3.3.4
-dm-control==1.0.31
+mujoco>=3.4,<3.5
+dm-control==1.0.36
 Pillow
 pink-noise-rl
 packaging
 gitpython
 
 # MYOASSIST FRAMEWORK (composed architecture: human MSK + assistive device + terrain)
-# MyoSuite is published on PyPI and installs directly (2.8.4 verified against this stack).
-myosuite
-# The three sibling packages below are not on PyPI, so they install from git.
-# Contributors doing local multi-repo development should instead clone these three
-# and `pip install -e <local_clone>` (as the dev env does) so local edits are picked
-# up without reinstalling.
-git+https://github.com/MyoHub/myo_sim.git@dev
-git+https://github.com/neumovelab/assist_sim.git
-git+https://github.com/neumovelab/myoassist.terrains.git
+
+# Install with `uv pip install -e .`, not plain pip. MyoSuite 2.8.4's metadata pins
+# mujoco==3.1.2 and dm-control==1.0.16, but it runs on mujoco 3.4, which the three
+# sibling packages below require. 
+
+# The `[tool.uv] override-dependencies` in pyproject.toml
+# relaxes those two pins so uv resolves the whole stack in one command; plain pip cannot.
+
+# Contributors doing local multi-repo development can instead clone the three siblings and
+# `uv pip install -e <local_clone>` so local edits are picked up without reinstalling.
+
+myosuite==2.8.4
+myo-sim>=0.2.1
+assist-sim>=0.7.0
+myoassist-terrains>=0.1.0
 
 # RL
 stable-baselines3

--- a/rl_train/envs/myoassist_leg_base.py
+++ b/rl_train/envs/myoassist_leg_base.py
@@ -41,9 +41,6 @@ class MyoAssistLegBase(env_base.MujocoEnv):
     ]
 
     def __init__(self, model_path, obsd_model_path=None, seed=None, **kwargs):
-
-        print(f"=================environment seed: {seed}=====================")
-        print(f"=================environment model_path: {model_path}=====================")
         # EzPickle.__init__(**locals()) is capturing the input dictionary of the init method of this class.
         # In order to successfully capture all arguments we need to call gym.utils.EzPickle.__init__(**locals())
         # at the leaf level, when we do inheritance like we do here.

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,12 @@ def fetch_requirements():
 
     Comments, blank lines, pip option lines (``-r``/``-e``/``--``) and bare
     VCS URLs (``git+https://...``) are skipped: setuptools' ``install_requires``
-    only accepts PEP 508 specifiers, so the git-hosted sibling packages
-    (myo_sim / assist_sim / myoassist.terrains) install via
-    ``pip install -r requirements.txt`` rather than through the wheel metadata.
+    only accepts PEP 508 specifiers. The sibling packages (myo-sim / assist-sim /
+    myoassist-terrains) are on PyPI and forward straight into ``install_requires``.
+
+    Install with ``uv pip install -e .``. MyoSuite 2.8.4's metadata pins an older
+    MuJoCo, and the ``[tool.uv] override-dependencies`` in pyproject.toml relaxes it
+    so the full stack resolves in one command; plain pip cannot do this.
     """
     reqs = []
     with open("requirements.txt", "r", encoding="utf-8", errors="ignore") as f:
@@ -57,6 +60,7 @@ if __name__ == "__main__":
         url="https://github.com/neumovelab/myoassist",
         classifiers=[
             "Programming Language :: Python :: 3.11",
+            "Programming Language :: Python :: 3.12",
             "License :: OSI Approved :: Apache Software License",
             "Topic :: Scientific/Engineering :: Artificial Intelligence :: Simulation",
             "Operating System :: OS Independent",

--- a/test_setup.py
+++ b/test_setup.py
@@ -250,35 +250,18 @@ class SetupTester:
 
             env.get_sensor_data()
 
-            from ctrl_optim.optim.cost_functions.walk_cost import func_Walk_FitCost
-
-            dummy_params = np.random.rand(
-                77,
-            )
-            optim_type = "Kine"
-            one_step = np.random.rand(100, 10)
-            one_EMG = np.random.rand(100, 10)
-            trunk_err_type = "ref_diff"
-            input_tgt_vel = 1.25
-            stride_num = 1
-            tgt_sym = 0.1
-            tgt_grf = 1.5
-
-            try:
-                cost = func_Walk_FitCost(
-                    params=dummy_params,
-                    optim_type=optim_type,
-                    one_step=one_step,
-                    one_EMG=one_EMG,
-                    trunk_err_type=trunk_err_type,
-                    input_tgt_vel=input_tgt_vel,
-                    stride_num=stride_num,
-                    tgt_sym=tgt_sym,
-                    tgt_grf=tgt_grf,
-                )
-                assert isinstance(cost, (float, dict)), "Invalid cost function output"
-            except Exception as e:
-                print(f"Cost function test completed (simulation failure expected): {str(e)[:100]}...")
+            # Run a short reflex rollout and confirm the cost pipeline returns a cost.
+            # This drives the CO objective path (reflex control -> physics step ->
+            # per-step cost) for about half a second. Any error here is a real failure,
+            # not an "expected" one, so it is not swallowed.
+            env.reset(control_params)
+            rollout_steps = int(0.5 / env.dt)
+            cost_dict = None
+            for _ in range(rollout_steps):
+                cost_dict, _sim_time, done = env.run_reflex_step_Cost()
+                if done:
+                    break
+            assert isinstance(cost_dict, dict) and cost_dict, "Reflex rollout returned no cost"
 
         except Exception as e:
             raise RuntimeError(f"Reflex environment initialization failed: {e}")


### PR DESCRIPTION
One-command uv flow (PyPI siblings plus a pyproject uv override pinning myosuite 2.8.4, mujoco 3.4, and dm-control 1.0.36), and tidy the env debug prints and the reflex cost smoke test.